### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
   "perl" : "6.c",
   "name" : "Linux::Process::SignalInfo",
+  "license" : "Artistic-2.0",
   "description" : "Show process signal information on Linux",
   "tags" : [ "linux", "utils", "signal" ],
   "authors" : [ "Cuong Manh Le <cuong.manhle@gmail.com>" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license